### PR TITLE
Update flake8 ignores

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ commands =
 # E123, E125 skipped as they are invalid PEP-8.
 
 show-source = True
-ignore = E123,E125,E402,W503
+ignore = E123,E125,E203,E402,E741,F401,W503
 max-line-length = 160
 builtins = _
 exclude = .git,.tox


### PR DESCRIPTION
We don't want to do this long term, but it allows us to move forward
merging code for nxos.  We'll fix this in ansible/ansible as we move
forward.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>