### PR TITLE
Relate flake8 rules

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ commands = {posargs}
 # E123, E125 skipped as they are invalid PEP-8.
 
 show-source = True
-ignore = E123,E125,E203,E402,E741,F401,W503
+ignore = E123,E125,E203,E402,E741,F401,F811,F841,W503
 max-line-length = 160
 builtins = _
 exclude = .git,.tox


### PR DESCRIPTION
With stable-2.9 branch, relax flake8 rules, so we can let migration
script pass. Then work to fix the issues.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>